### PR TITLE
Changes on syntax highlight

### DIFF
--- a/202001.0/f9db1f38-70b3-4970-a7f1-4329c1c2d774.md
+++ b/202001.0/f9db1f38-70b3-4970-a7f1-4329c1c2d774.md
@@ -58,7 +58,7 @@ Create the template file that was added to your widget's    `getTemplate()` meth
 
 src/Pyz/Yves/FooModule/Theme/default/views/foo-bar-widget/foo-bar-widget.twig
 
-```json
+```html
 {% extends template('widget') %}
 
 {% define data = {
@@ -109,14 +109,14 @@ Widgets are placed and rendered in twig templates. The following examples show s
 
 **Simple widget rendering with input parameters:**
 
-```json
+```html
 {% widget 'FooWidget' args [param1, param2] only %}
 {% endwidget %}
 ```
 
 **Widget rendering with different templates:**
 
-```json
+```html
 {% widget 'FooWidget' use view('view1') only %}
 {% endwidget %}
  
@@ -126,7 +126,7 @@ Widgets are placed and rendered in twig templates. The following examples show s
 
 **Widget rendering with additional HTML:**
 
-```json
+```html
 {% set color = 'red' %}
  
 {% if widgetExists('FooWidgetPlugin') %}
@@ -138,7 +138,7 @@ Widgets are placed and rendered in twig templates. The following examples show s
 
 **Widget rendering with additional HTML and context variables:**
 
-```json
+```html
 {% widget 'FooWidget' args [param1, param2] with {color: 'red'} only %}
 	{% block body %}
 		<div style="border:1px solid {{ color }}">
@@ -150,7 +150,7 @@ Widgets are placed and rendered in twig templates. The following examples show s
 
 **Widget rendering with fallback when it doesn't exist or not activated:**
 
-```json
+```html
 {% widget 'FooWidget' args [param1, param2] only %}
 {% nowidget %}
 	display something else here...
@@ -159,14 +159,14 @@ Widgets are placed and rendered in twig templates. The following examples show s
 
 **Render widget into a variable:**
 
-```json
+```html
 {% set fooWidget = findWidget('FooWidget', [param1, param2]) %}
 {% set foo = fooWidget.foo|default %}
 ```
 
 **Subsequently, render widgets as a fallback when another widget doesn't exist:**
 
-```json
+```html
 {% widget 'FooWidget' only %}
 {% elsewidget 'BarWidget' only %}
 {% nowidget %}
@@ -187,7 +187,7 @@ In the module you are planning to extend, find the extension point in the twig t
 
 @MyPage/views/foo/foo-bar.twig
 
-```json
+```html
 <p>Some MyPage related content.</p>
  
 {{ widget('MyWidgetPlugin', $param1, param2) }}
@@ -297,7 +297,7 @@ Create the template file that was added to your Widget's `getTemplate()` method 
 
 src/Pyz/Yves/MyWidget/Theme/default/views/my-widget/my-widget.twig
 
-```json
+```html
 {% extends template('widget') %}
 
 {% define data = {


### PR DESCRIPTION
Changed the syntax to HTML, even tho the highlight is not really changed, but at least is not misleading (as it should be HTML and Twig)