### PR TITLE
Removed redundant information

### DIFF
--- a/202001.0/8d57ad63-f1fc-4ee9-85ee-2e19138374ca.md
+++ b/202001.0/8d57ad63-f1fc-4ee9-85ee-2e19138374ca.md
@@ -96,11 +96,7 @@ Spryker provides the basic functionality to generate [OpenApi schema specificati
 ### Configuration
 
     
-1. Run the command to install the required Docker SDK version:
-```bash
-    git clone https://github.com/spryker/docker-sdk.git 1.3.0 ./docker
-```
-2. Adjust `deploy.*.yml` in the `services:` section:
+1. Adjust `deploy.*.yml` in the `services:` section:
 ```yml	
 services:
     ...


### PR DESCRIPTION
We state at the beginning of the article that the user should get the latest version of the `docker-sdk`, then it makes the second statement irrelevant.