### PR TITLE
Fix link

### DIFF
--- a/202001.0/ff592214-00bb-42bc-b994-21724f6f85d9.md
+++ b/202001.0/ff592214-00bb-42bc-b994-21724f6f85d9.md
@@ -220,7 +220,7 @@ Add the Process module on project level and specify configuration profiles in `P
 }    
 ```
 
-See [this example](https://github.com/spryker-eco/akeneo-pim-middleware-connector/blob/feature/ECO-1205-update-module-according-to-middleware-changes/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/DefaultProductImportConfigurationPlugin.php) on how to implement a process.
+See [this example](https://github.com/spryker-eco/akeneo-pim-middleware-connector/blob/master/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/DefaultProductImportConfigurationPlugin.php) on how to implement a process.
 
 ### Middleware Reports
 


### PR DESCRIPTION
Fix link to DefaultProductImportConfigurationPlugin.php .
The link leads to a file on a branch that does not exist anymore. The file is now on the master branch.