### PR TITLE
Update c4a5566f-482d-44a7-9f72-2bd04ed8c257.md

### DIFF
--- a/Code releases 05.20/c4a5566f-482d-44a7-9f72-2bd04ed8c257.md
+++ b/Code releases 05.20/c4a5566f-482d-44a7-9f72-2bd04ed8c257.md
@@ -39,7 +39,7 @@ class SubscriptionFormType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('email', 'email', [
+        $builder->add('email', EmailType::class, [
             'label' => 'Email',
             'constraints' => [
                 new NotBlank(),
@@ -68,9 +68,7 @@ class NewsletterFactory extends AbstractFactory
      */
     public function createSubscriptionForm()
     {
-        $subscriptionFormType = new SubscriptionFormType();
-
-        return $this->getFormFactory()->create($subscriptionFormType);
+        return $this->getFormFactory()->create(SubscriptionFormType::class);
     }
 
 }
@@ -113,6 +111,7 @@ class SubscriptionController extends AbstractController
 
 Add the form in your template together with a submit button; make sure you use the same string as in the controller action (`subscriptionForm`).
 
+
 ```php
 {{ form_start(subscriptionForm) }}
     {{ form_widget(subscriptionForm.email) }}
@@ -148,7 +147,7 @@ class SubscriptionController extends AbstractController
             ->createSubscriptionForm()
             ->handleRequest($request);
 
-        if ($subscriptionForm->isValid()) {
+       if ($subscriptionForm->isSubmitted() && $subscriptionForm->isValid()) {
             // Call the client for e.g. to save the subscriber.
 
             // Redirect to home page after successful subscription


### PR DESCRIPTION
- use isSubmitted before isValid to prevent exception
- to build an email field nowerdays you have to use EmailType::class insteas of string
- the formfactory now needs the concrete classname "SubscriptionFormType::class"