### PR TITLE
Update f194c2fe-9c00-436e-a3ab-250764a9aae6.md

### DIFF
--- a/Code releases 05.20/f194c2fe-9c00-436e-a3ab-250764a9aae6.md
+++ b/Code releases 05.20/f194c2fe-9c00-436e-a3ab-250764a9aae6.md
@@ -24,7 +24,7 @@ class PriceFilter
     /**
      * @return string
      */
-    protected function getCurrency()
+    protected function getCurrency(): string
     {
         // here can be more logic to get the used currency
         return '&euro;';
@@ -33,7 +33,7 @@ class PriceFilter
     /**
      * @return string
      */
-    public function getConvertedPrice($price)
+    public function getConvertedPrice($price): string
     {
         // here could be more logic to convert the price if it needs to be displayed in a different currency
         return sprintf(
@@ -57,9 +57,9 @@ use Spryker\Service\Kernel\AbstractServiceFactory;
 class ServiceFactory extends AbstractServiceFactory
 {
     /**
-     * @return Pyz\Service\ExampleBundle\Plugin\Twig\Filters\PriceFilter
+     * @return \Pyz\Service\ExampleBundle\Plugin\Twig\Filters\PriceFilter
      */
-    public function createPriceFilter()
+    public function createPriceFilter(): PriceFilter
     {
         return new PriceFilter();
     }
@@ -80,7 +80,7 @@ class PriceFilterService extends AbstractService implements PriceFilterServiceIn
      *
      * @return string
      */
-    public function getConvertedPrice($price)
+    public function getConvertedPrice(int $price): string
     {
         return $this->getFactory()->createPriceFilter()->getConvertedPrice($price);
     }
@@ -101,7 +101,7 @@ use Spryker\Service\Twig\Plugin\AbstractTwigExtensionPlugin;
 use Spryker\Shared\Twig\TwigFilter;
 
 /**
- * @method \Pyz\Service\ExampleBundle\Plugin\Twig\Filters\PriceFilterService getService()
+ * @method \Pyz\Service\ExampleBundle\PriceFilterService getService()
  */
 class ExampleTwigExtensionPlugin extends AbstractTwigExtensionPlugin
 {
@@ -109,7 +109,7 @@ class ExampleTwigExtensionPlugin extends AbstractTwigExtensionPlugin
     /**
      * @return array
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter(
@@ -134,14 +134,13 @@ First, add a reference to the Twig extension in `TwigDependencyProvider.php`:
 use Pyz\Service\ExampleBundle\Plugin\Twig\ExampleTwigExtensionPlugin;
 
 // Instantiate the new Twig extension
-protected function getTwigPlugins(Application $app)
+protected function getTwigPlugins(Application $app): array
 {
     return [
-        ...
         new ExampleTwigExtensionPlugin(),
     ];
 }
-```
+
 
 ## Test the Twig Extension
 Now, the Twig extension is ready to be used in the Twig templates.


### PR DESCRIPTION
I added return types and fixed the obvious typos. I am testing this example right now and really hope it would world later. As far as I can see the TwigDependencyProvider is part of this service and provides the method to register. I have to no how this is discovered by the system. And  a full implementation of this class would be an amazing addidtion as this is not an extension of Spryker core as the other plugin providers.

And this is should really not be called "Bundle". Bundle is a Symfony Term for Symfony bundles which is now not even common enymore as they use Flex and no bundle.php anymore. As far as I know Spryker you commonly use the Term "Module" or in this case it is probably a Service.