### PR TITLE
Fix typo in Spryker Middleware docu

### DIFF
--- a/Code releases 05.20/cc6aaccf-32c7-48b2-b3d4-100891d75db5.md
+++ b/Code releases 05.20/cc6aaccf-32c7-48b2-b3d4-100891d75db5.md
@@ -597,7 +597,7 @@ Use the following format to define translation rules:
 						'TranslatorFunction3',
 					],
 				],
-				'mapped_key.*.subkey => [
+				'mapped_key.*.subkey' => [
 					[
 						'TranslatorFunction4',
 					],

--- a/Code releases 05.20/cc6aaccf-32c7-48b2-b3d4-100891d75db5.md
+++ b/Code releases 05.20/cc6aaccf-32c7-48b2-b3d4-100891d75db5.md
@@ -78,7 +78,7 @@ You can use one of two iterators that are provided out of the box (NullIterator,
 
 **getLoggerPlugin** - defines the way logging happens. The default Middleware logger logs to the PHP standard error stream (php://stderr) (this can be changed as needed). Detalization of the logging is fully customizable, which means you can configure it as you wish.
 
-**getPreProcessorHookPlugins** and **getPreProcessorHookPlugins** - define what should be done prior to or after a process. For example, it might be necessary to download a file with the categories prior to the categories import: this would be specified in `getPreProcessHookPlugins`.
+**getPreProcessorHookPlugins** and **getPostProcessorHookPlugins** - define what should be done prior to or after a process. For example, it might be necessary to download a file with the categories prior to the categories import: this would be specified in `getPreProcessHookPlugins`.
 
 ```php
 class CategoryImportConfigurationPlugin extends AbstractPlugin implements ProcessConfigurationPluginInterface
@@ -178,7 +178,7 @@ composer require spryker-middleware/process
 Add the `SprykerMiddleware` namespace to your project’s core namespaces:
 
 ```bash
-$config[ KernelConstants::CORE_NAMESPACES] = [
+$config[KernelConstants::CORE_NAMESPACES] = [
    'SprykerShop',
    'SprykerMiddleware',
    'SprykerEco',
@@ -189,10 +189,10 @@ $config[ KernelConstants::CORE_NAMESPACES] = [
 Add the Middleware Process console command to `ConsoleDependencyProvider` in your project:
 
 ```php
-	…
+…
 use SprykerMiddleware\Zed\Process\Communication\Console\ProcessConsole;
 …
-protected function getConsoleCommands(Container $container)
+protected function getConsoleCommands(Container $container): array
 {
    $commands = [
        … 
@@ -206,7 +206,7 @@ protected function getConsoleCommands(Container $container)
 Add the Process module on project level and specify configuration profiles in `ProcessDependencyProvider`:
 
 ```php
-	class ProcessDependencyProvider extends SprykerMiddlewareProcessDependencyProvider
+class ProcessDependencyProvider extends SprykerMiddlewareProcessDependencyProvider
 {
     …
    protected function getConfigurationProfilePluginsStack(): array


### PR DESCRIPTION
Replaced `getPreProcessorHookPlugins` to `getPostProcessorHookPlugins `