### PR TITLE
Set correct namespace for RouteProviderPlugin

### DIFF
--- a/Code releases 05.20/dd1d1d6d-bda1-4cdb-b09d-7e252f49191d.md
+++ b/Code releases 05.20/dd1d1d6d-bda1-4cdb-b09d-7e252f49191d.md
@@ -41,12 +41,12 @@ class IndexController extends AbstractController
 3. Add the route to the controller:
     1. Add a new folder inside the HelloWorld module called `Plugin`.
     2. Inside the **Plugin** folder, add a folder called **Provider**.
-    3. Add your `ControllerProvider` class with the name `HelloWorldControllerProvider`:
+    3. Add your `ControllerProvider` class with the name `HelloWoldRouteProviderPlugin`:
 
 ```php
 <?php
 
-namespace Pyz\Yves\HelloSpryker\Plugin\Provider;
+namespace Pyz\Yves\HelloWorld\Plugin\Provider;
 
 use Spryker\Yves\Router\Plugin\RouteProvider\AbstractRouteProviderPlugin;
 use Spryker\Yves\Router\Route\RouteCollection;

--- a/Code releases 05.20/dd1d1d6d-bda1-4cdb-b09d-7e252f49191d.md
+++ b/Code releases 05.20/dd1d1d6d-bda1-4cdb-b09d-7e252f49191d.md
@@ -1,11 +1,11 @@
 @(Info)()(This tutorial is also available on the Spryker Training web-site. For more information and hands-on exercises, visit the [Spryker Training](https://training.spryker.com/courses/developer-bootcamp) web-site.)
 
 ## Challenge Description
-Show "Hello World!" string on a web page on your browser. To do so, build a new module called **HelloWold**.
+Show "Hello World!" string on a web page on your browser. To do so, build a new module called **HelloWorld**.
 
-## Build the HelloWold Module
-The steps described in this procedure describe how to build a new module.  To add a new Yves module called **HelloWold**, do the following:
-1. Go to `/src/Pyz/Yves/` and add a new module called HelloWold.
+## Build the HelloWorld Module
+The steps described in this procedure describe how to build a new module.  To add a new Yves module called **HelloWorld**, do the following:
+1. Go to `/src/Pyz/Yves/` and add a new module called HelloWorld.
 @(Info)()(A new module is simply a new folder. )
 2. Add a new controller for the module. 
 Add a new folder inside the HelloWorld module called `Controller`, and then add the following controller class called `IndexController`:
@@ -13,7 +13,7 @@ Add a new folder inside the HelloWorld module called `Controller`, and then add 
 ```php
 <?php
 
-namespace Pyz\Yves\HelloWold\Controller;
+namespace Pyz\Yves\HelloWorld\Controller;
  
 use Spryker\Yves\Kernel\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,7 +32,7 @@ class IndexController extends AbstractController
 			return $this->view(
 				$data,
 				[],
-				'@HelloWold/views/index/index.twig'
+				'@HelloWorld/views/index/index.twig'
 			);
 		}
 }
@@ -41,7 +41,7 @@ class IndexController extends AbstractController
 3. Add the route to the controller:
     1. Add a new folder inside the HelloWorld module called `Plugin`.
     2. Inside the **Plugin** folder, add a folder called **Provider**.
-    3. Add your `ControllerProvider` class with the name `HelloWoldRouteProviderPlugin`:
+    3. Add your `ControllerProvider` class with the name `HelloWorldRouteProviderPlugin`:
 
 ```php
 <?php
@@ -51,7 +51,7 @@ namespace Pyz\Yves\HelloWorld\Plugin\Provider;
 use Spryker\Yves\Router\Plugin\RouteProvider\AbstractRouteProviderPlugin;
 use Spryker\Yves\Router\Route\RouteCollection;
  
-class HelloWoldRouteProviderPlugin extends AbstractRouteProviderPlugin
+class HelloWorldRouteProviderPlugin extends AbstractRouteProviderPlugin
 {
 	protected const ROUTE_HELLO_WORLD = 'hello-world';
  
@@ -62,7 +62,7 @@ class HelloWoldRouteProviderPlugin extends AbstractRouteProviderPlugin
          */
         public function addRoutes(RouteCollection $routeCollection): RouteCollection
         {
-            $route = $this->buildRoute('/hello-world', 'HelloWold', 'Index', 'indexAction');
+            $route = $this->buildRoute('/hello-world', 'HelloWorld', 'Index', 'indexAction');
             $routeCollection->add(static::ROUTE_HELLO_WORLD, $route);
 
             return $routeCollection;
@@ -70,8 +70,8 @@ class HelloWoldRouteProviderPlugin extends AbstractRouteProviderPlugin
 }
 ```
 4. Register the `RouteProviderPlugin` in the application, so the application knows about your controller action.
-Go to `RouterDependencyProvider::getRouteProvider()` method in `Router` module and add `HelloWoldRouteProviderPlugin` to the array.
-5. Finally, add the twig file to render your Hello World page. Add the following folder structure inside the **HelloWold** module: `Theme/default/views/index`. 
+Go to `RouterDependencyProvider::getRouteProvider()` method in `Router` module and add `HelloWorldRouteProviderPlugin` to the array.
+5. Finally, add the twig file to render your Hello World page. Add the following folder structure inside the **HelloWorld** module: `Theme/default/views/index`. 
 
 @(Info)()(This folder structure reflects your theme and controller names. Default is the theme name, and index is the controller name. For every action there is a template with the same name.)
 


### PR DESCRIPTION
## PR Description

Currently there is a typo for the namespace in the hello world section. Instead of `HelloWorld` ist was `HelloSpryker`.

Also there were many typos in the word "World" - it was typed "Wold".

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
