### PR TITLE
Update 15f2fc9a-73d5-498e-93d7-8a906e08733f.md

### DIFF
--- a/Code releases 05.20/15f2fc9a-73d5-498e-93d7-8a906e08733f.md
+++ b/Code releases 05.20/15f2fc9a-73d5-498e-93d7-8a906e08733f.md
@@ -14,7 +14,7 @@ And the interfaces which are implemented everywhere are also part of the API:
 
 In addition to these obvious cases, there are some other classes which are part of the API and can cause a BC break:
 
-* module Config (`Client/Yves/Zed/Shared/Service`)(https://documentation.spryker.com/docs/configuration-management#how-to-retrieve-the-configuration)
+* [module Config](https://documentation.spryker.com/docs/configuration-management#how-to-retrieve-the-configuration) (`Client/Yves/Zed/Shared/Service`)
 * Controllers
 * Twig functions
 * [CLI commands](https://documentation.spryker.com/docs/console-commands)


### PR DESCRIPTION
* moves link to module Config

Question to maintainers: Is the (`Client/Yves/Zed/Shared/Service`) text part of the link?

