### PR TITLE
Update eaad24c4-9d03-48fb-b0c8-d0be8bbfa5d2.md

### DIFF
--- a/Code releases 05.20/eaad24c4-9d03-48fb-b0c8-d0be8bbfa5d2.md
+++ b/Code releases 05.20/eaad24c4-9d03-48fb-b0c8-d0be8bbfa5d2.md
@@ -15,7 +15,6 @@ Add sub form plugins and payment method handlers:
 namespace Pyz\Yves\CheckoutPage;
  
 ...
-use Spryker\Yves\StepEngine\Dependency\Plugin\Form\SubFormPluginCollection;
 use SprykerEco\Shared\Adyen\AdyenConfig;
 use SprykerEco\Yves\Adyen\Plugin\AdyenPaymentHandlerPlugin;
 use SprykerEco\Yves\Adyen\Plugin\StepEngine\AdyenCreditCardSubFormPlugin;


### PR DESCRIPTION
use Spryker\Yves\StepEngine\Dependency\Plugin\Form\SubFormPluginCollection; is already present in the CheckoutPageDependencyProvider and does not need to get added.


