### PR TITLE
Added missing 'e' character in doc

### DIFF
--- a/202001.0/2fefc85f-fe20-446a-a91f-c1047057134b.md
+++ b/202001.0/2fefc85f-fe20-446a-a91f-c1047057134b.md
@@ -162,7 +162,7 @@ To fulfill our goal, we can use keyword _this_. It provides direct access to t
 Names of Javascript classes follow [Camel Case](http://wiki.c2.com/?CamelCase), thus, the behavior of our component will be implemented by Javascript class `NewComponentCounter`:
 
 ```Javascript
-xport default class NewComponentCounter extends Component {
+export default class NewComponentCounter extends Component {
     protected counter: HTMLElement
     protected elements: HTMLElement[]
 


### PR DESCRIPTION
Only single change regarding missing `e` character in .ts `export` word. Just a typo.


