### PR TITLE
Creating Forms | Fixed typo in doc-block namespaces

### DIFF
--- a/202009.0/23bd8590-94d7-47c3-874e-00b9a6b1d9d5.md
+++ b/202009.0/23bd8590-94d7-47c3-874e-00b9a6b1d9d5.md
@@ -87,7 +87,7 @@ namespace Pyz\Yves\Newsletter\Controller;
 use Spryker\Yves\Kernel\Controller\AbstractController;
 
 /**
- * @method \Pyz\Yves\Newslette\NewsletterFactory getFactory()
+ * @method \Pyz\Yves\Newsletter\NewsletterFactory getFactory()
  */
 class SubscriptionController extends AbstractController
 {
@@ -130,7 +130,7 @@ namespace Pyz\Yves\Newsletter\Controller;
 use Spryker\Yves\Kernel\Controller\AbstractController;
 
 /**
- * @method \Pyz\Yves\Newslette\NewsletterFactory getFactory()
+ * @method \Pyz\Yves\Newsletter\NewsletterFactory getFactory()
  */
 class SubscriptionController extends AbstractController
 {


### PR DESCRIPTION
Fixed typo in doc-block namespaces


