### PR TITLE
Update b226ab2a-b373-4547-b840-a45edfad3c0e.md

### DIFF
--- a/202009.0/b226ab2a-b373-4547-b840-a45edfad3c0e.md
+++ b/202009.0/b226ab2a-b373-4547-b840-a45edfad3c0e.md
@@ -300,7 +300,7 @@ namespace Pyz\Zed\DataImport;
 
 use Spryker\Zed\DataImport\DataImportDependencyProvider as SprykerDataImportDependencyProvider;
 use Spryker\Zed\ProductRelationDataImport\Communication\Plugin\ProductRelationDataImportPlugin;
-use Spryker\Zed\ProductRelationDataImport\Communication\Plugin\ProductRelationStoreStoreDataImportPlugin;
+use Spryker\Zed\ProductRelationDataImport\Communication\Plugin\ProductRelationStoreDataImportPlugin;
 
 class DataImportDependencyProvider extends SprykerDataImportDependencyProvider
 {
@@ -311,7 +311,7 @@ class DataImportDependencyProvider extends SprykerDataImportDependencyProvider
     {
         return [
             new ProductRelationDataImportPlugin(),
-            new ProductRelationStoreStoreDataImportPlugin(),
+            new ProductRelationStoreDataImportPlugin(),
         ];
     }
 }


### PR DESCRIPTION
Typo in `ProductRelationStoreStoreDataImportPlugin` classname, `ProductRelationStoreDataImportPlugin` is correct one (also used above in text).


