### PR TITLE
Update 2f2bd753-794f-474b-a4d3-dde5bbefdb29.md

### DIFF
--- a/202009.0/2f2bd753-794f-474b-a4d3-dde5bbefdb29.md
+++ b/202009.0/2f2bd753-794f-474b-a4d3-dde5bbefdb29.md
@@ -2,6 +2,8 @@ This document describes how to configure basic htaccess authentication for the S
 
 To set up htaccess authentication, follow the instructions below.
 
+Attention: Please note that it is not possible to protect GLUE endpoints with basic auth and the use of basic auth for production environments is not recommendable. Please look into other options, like IP whitelisting, instead.
+
 ## 1. Defining login details and endpoints
 To define login details and endpoints:
 


### PR DESCRIPTION
Please add disclaimer that it is not possible to cover GLUE with Basic Auth and that using Basic auth for production environment is discouraged. If people want to secure GLUE endpoints they should go for firewall options, like IP whitelisting, instead.


