### PR TITLE
Remove suggestion to have multiple domains

### DIFF
--- a/202009.0/fa59ee78-aaf0-4d63-8154-fbd8b60c6168.md
+++ b/202009.0/fa59ee78-aaf0-4d63-8154-fbd8b60c6168.md
@@ -31,13 +31,11 @@ $config[GlueApplicationConstants::GLUE_APPLICATION_CORS_ALLOW_ORIGIN] = '';
 $config[GlueApplicationConstants::GLUE_APPLICATION_CORS_ALLOW_ORIGIN] = '*';
 ```
 
-    * `http://www.example1.com/ http://www.example2.com/` - allow CORS requests only from the specified origins. Example:
+    * `http://www.example1.com` - allow CORS requests only from the specified origin. Example:
 
 ```php
-$config[GlueApplicationConstants::GLUE_APPLICATION_CORS_ALLOW_ORIGIN] = 'http://www.example1.com/ http://www.example2.com/';
+$config[GlueApplicationConstants::GLUE_APPLICATION_CORS_ALLOW_ORIGIN] = 'http://www.example1.com';
 ```
-
-@(Info)()(In constraint environments, it is recommended to have only **1** domain allowed for CORS requests.)
 
 3. Save the file.
 


### PR DESCRIPTION
Having multiple domains in a CORS header is violating an official specification: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin

More over, there is one alternative way of setting CORS headers, via the docker/sdk: https://github.com/spryker/docker-sdk/blob/master/docs/99-deploy.file.reference.v1.md:

```
groups: applications: endpoints: cors-allow-origin: defines a CORS header. It is allowed for glue application only. Possible values are single domain as string or * to allow all domains.
```


