### PR TITLE
Update 1f090798-995c-45cf-99e1-71d2e8290777.md

### DIFF
--- a/202009.0/1f090798-995c-45cf-99e1-71d2e8290777.md
+++ b/202009.0/1f090798-995c-45cf-99e1-71d2e8290777.md
@@ -46,7 +46,7 @@ $config[OmsConstants::ACTIVE_PROCESSES] = [
 ```xml
 <states>
 	<state name="new" />
-    </states>
+</states>
 ```
     
 5. Check the state machine graph while building it.


### PR DESCRIPTION
Un-Indent states closing tag

At first glance this is confusing since the above state tag is self closing
