### PR TITLE
[BUGFIX] Removed the block about functionality we don't have at the moment.

### DIFF
--- a/202009.0/5dc7f1b6-3cef-44e1-8302-5d4e23e0cf0c.md
+++ b/202009.0/5dc7f1b6-3cef-44e1-8302-5d4e23e0cf0c.md
@@ -279,8 +279,6 @@ Transfers expose the new *get-collection-item* methods for all the `associative`
 <property name=“items” type=“string[]” singular=“item” associative=“true”/>
 ```
 
-a new method `::getItem($key): string` will be available.
-
 @(Warning)()(If you extend the existing transfer object, don't copy over all fields, but only the fields you want to add on top.)
 
 ## Transfer definition validation


### PR DESCRIPTION
There's no `getItem($key)` method, according to our [RFC](https://spryker.atlassian.net/wiki/spaces/RFC/pages/7438337/ACCEPTED+RFC+Associative+collections+and+arrays+in+Transfers) and code also.
