### PR TITLE
Update 9ebd7c8a-d735-4bb3-8533-4c48b7ddba5d.md

### DIFF
--- a/202009.0/9ebd7c8a-d735-4bb3-8533-4c48b7ddba5d.md
+++ b/202009.0/9ebd7c8a-d735-4bb3-8533-4c48b7ddba5d.md
@@ -8,7 +8,7 @@ To reset a Docker environment:
 
 1. Delete all containers, networks, unused images, and build cache:
 ```bash
-sudo docker system prune
+sudo docker/sdk system prune
 ```
 2. In the project root directory, clean data, bootstrap the deploy file and start the instance:
 ```bash

--- a/202009.0/9ebd7c8a-d735-4bb3-8533-4c48b7ddba5d.md
+++ b/202009.0/9ebd7c8a-d735-4bb3-8533-4c48b7ddba5d.md
@@ -8,7 +8,7 @@ To reset a Docker environment:
 
 1. Delete all containers, networks, unused images, and build cache:
 ```bash
-sudo docker prune
+sudo docker system prune
 ```
 2. In the project root directory, clean data, bootstrap the deploy file and start the instance:
 ```bash


### PR DESCRIPTION
i guess it should be `docker system prune` since `docker prune` does not exist.

[patrickjaja@patrickjaja-pc suite]$ sudo docker prune
[sudo] Passwort für patrickjaja: 
docker: 'prune' is not a docker command.
See 'docker --help'
[patrickjaja@patrickjaja-pc suite]$ docker system prune -a
WARNING! This will remove:
  - all stopped containers
  - all networks not used by at least one container
  - all images without at least one container associated to them
  - all build cache

