### PR TITLE
Fixed broken links to Gift Cards page.

### DIFF
--- a/202001.0/65ed0020-fdd7-4e1f-a43b-c5c802c46d38.md
+++ b/202001.0/65ed0020-fdd7-4e1f-a43b-c5c802c46d38.md
@@ -104,7 +104,7 @@ The Spryker B2С Suite is a collection of ready-to-use B2С-specific features. O
 * [Multiple Payment Methods per Order](https://documentation.spryker.com/docs/payment-methods-overview)
 * [Refund Management](https://documentation.spryker.com/docs/refund-management)
 
-[**Gift Cards**](https://documentation.spryker.com/docs/gift-cards):
+[**Gift Cards**](https://documentation.spryker.com/docs/gift-card):
 [Gift Cards Purchase & Management](https://documentation.spryker.com/docs/gift-card-purchase-management-201907)
 
 [**Checkout**](https://documentation.spryker.com/docs/checkout):

--- a/202009.0/03acbbf6-ee0f-4c2a-b665-6fd733f059bd.md
+++ b/202009.0/03acbbf6-ee0f-4c2a-b665-6fd733f059bd.md
@@ -1,4 +1,4 @@
-This article contains content of the **gift_card_concrete_configuration.csv** file to configure [Gift Card](https://documentation.spryker.com/docs/gift-cards) Concrete Configuration information on your Spryker Demo Shop. A **Gift Card Product** is a regular product in the shop which represents a Gift Card that Customer can buy. In this file,  you can configure the ammount of money that will be loaded in the Gift Card.
+This article contains content of the **gift_card_concrete_configuration.csv** file to configure [Gift Card](https://documentation.spryker.com/docs/gift-card) Concrete Configuration information on your Spryker Demo Shop. A **Gift Card Product** is a regular product in the shop which represents a Gift Card that Customer can buy. In this file, you can configure the amount of money that will be loaded in the Gift Card.
 
 ## Headers & Mandatory Fields 
 These are the header fields to be included in the .csv file:

--- a/202009.0/401cdcb2-f0fc-4422-afda-764c68239840.md
+++ b/202009.0/401cdcb2-f0fc-4422-afda-764c68239840.md
@@ -1,4 +1,4 @@
-This article contains content of the **gift_card_abstract_configuration.csv** file to configure [Gift Card](https://documentation.spryker.com/docs/gift-cards) Abstract Configuration information on your Spryker Demo Shop. A **Gift Card Product** is a regular product in the shop which represents a Gift Card that Customer can buy. The **Gift Card Abstract Product** represents a type of Gift Cards with a code pattern (e.g. "XMAS-", “Happy-B”, etc.).
+This article contains content of the **gift_card_abstract_configuration.csv** file to configure [Gift Card](https://documentation.spryker.com/docs/gift-card) Abstract Configuration information on your Spryker Demo Shop. A **Gift Card Product** is a regular product in the shop which represents a Gift Card that Customer can buy. The **Gift Card Abstract Product** represents a type of Gift Cards with a code pattern (e.g. "XMAS-", “Happy-B”, etc.).
 
 ## Headers & Mandatory Fields 
 These are the header fields to be included in the .csv file:

--- a/202009.0/754edd8c-0003-402e-b6e4-f0a49ad63f37.md
+++ b/202009.0/754edd8c-0003-402e-b6e4-f0a49ad63f37.md
@@ -1,4 +1,4 @@
-This article contains content of the **gift_card_concrete_configuration.csv** file to configure [Gift Card](https://documentation.spryker.com/docs/gift-cards) Concrete Configuration information on your Spryker Demo Shop. A **Gift Card Product** is a regular product in the shop which represents a Gift Card that Customer can buy. In this file,  you can configure the ammount of money that will be loaded in the Gift Card.
+This article contains content of the **gift_card_concrete_configuration.csv** file to configure [Gift Card](https://documentation.spryker.com/docs/gift-card) Concrete Configuration information on your Spryker Demo Shop. A **Gift Card Product** is a regular product in the shop which represents a Gift Card that Customer can buy. In this file,  you can configure the ammount of money that will be loaded in the Gift Card.
 
 ## Headers & Mandatory Fields 
 These are the header fields to be included in the .csv file:

--- a/202009.0/7c1fa4e8-2b26-4807-bd76-fd0f0d8914a8.md
+++ b/202009.0/7c1fa4e8-2b26-4807-bd76-fd0f0d8914a8.md
@@ -1,4 +1,4 @@
-This article contains content of the **gift_card_concrete_configuration.csv** file to configure [Gift Card](https://documentation.spryker.com/docs/gift-cards) Concrete Configuration information on your Spryker Demo Shop. A **Gift Card Product** is a regular product in the shop which represents a Gift Card that Customer can buy. In this file,  you can configure the ammount of money that will be loaded in the Gift Card.
+This article contains content of the **gift_card_concrete_configuration.csv** file to configure [Gift Card](https://documentation.spryker.com/docs/gift-card) Concrete Configuration information on your Spryker Demo Shop. A **Gift Card Product** is a regular product in the shop which represents a Gift Card that Customer can buy. In this file,  you can configure the ammount of money that will be loaded in the Gift Card.
 
 ## Headers & Mandatory Fields 
 These are the header fields to be included in the .csv file:

--- a/202009.0/8567f90c-05e8-4727-a8cb-d3891d4f3cff.md
+++ b/202009.0/8567f90c-05e8-4727-a8cb-d3891d4f3cff.md
@@ -105,7 +105,7 @@ The Spryker B2С Suite is a collection of ready-to-use B2С-specific features. O
 * [Multiple Payment Methods per Order](https://documentation.spryker.com/docs/payment-methods-overview)
 * [Refund Management](https://documentation.spryker.com/docs/refund-management)
 
-[**Gift Cards**](https://documentation.spryker.com/docs/gift-cards):
+[**Gift Cards**](https://documentation.spryker.com/docs/gift-card):
 [Gift Cards Purchase & Management](https://documentation.spryker.com/docs/gift-card-purchase-management-201907)
 
 [**Checkout**](https://documentation.spryker.com/docs/checkout):

--- a/202009.0/c0eeeba8-90a3-4f25-bbd7-bbda769bac32.md
+++ b/202009.0/c0eeeba8-90a3-4f25-bbd7-bbda769bac32.md
@@ -1,4 +1,4 @@
-This article contains content of the **gift_card_abstract_configuration.csv** file to configure [Gift Card](https://documentation.spryker.com/docs/gift-cards) Abstract Configuration information on your Spryker Demo Shop. A **Gift Card Product** is a regular product in the shop which represents a Gift Card that Customer can buy. The **Gift Card Abstract Product** represents a type of Gift Cards with a code pattern (e.g. "XMAS-", “Happy-B”, etc.).
+This article contains content of the **gift_card_abstract_configuration.csv** file to configure [Gift Card](https://documentation.spryker.com/docs/gift-card) Abstract Configuration information on your Spryker Demo Shop. A **Gift Card Product** is a regular product in the shop which represents a Gift Card that Customer can buy. The **Gift Card Abstract Product** represents a type of Gift Cards with a code pattern (e.g. "XMAS-", “Happy-B”, etc.).
 
 ## Headers & Mandatory Fields 
 These are the header fields to be included in the .csv file:

--- a/202009.0/eb4f0378-0b5e-4b82-a7bf-53158197911f.md
+++ b/202009.0/eb4f0378-0b5e-4b82-a7bf-53158197911f.md
@@ -105,7 +105,7 @@ The Spryker B2С Suite is a collection of ready-to-use B2С-specific features. O
 * [Multiple Payment Methods per Order](https://documentation.spryker.com/docs/payment-methods-overview)
 * [Refund Management](https://documentation.spryker.com/docs/refund-management)
 
-[**Gift Cards**](https://documentation.spryker.com/docs/gift-cards):
+[**Gift Cards**](https://documentation.spryker.com/docs/gift-card):
 [Gift Cards Purchase & Management](https://documentation.spryker.com/docs/gift-card-purchase-management-201907)
 
 [**Checkout**](https://documentation.spryker.com/docs/checkout):

--- a/202009.0/fb50d1ff-0db9-460c-a382-85d13cf52d0c.md
+++ b/202009.0/fb50d1ff-0db9-460c-a382-85d13cf52d0c.md
@@ -1,4 +1,4 @@
-This article contains content of the **gift_card_abstract_configuration.csv** file to configure [Gift Card](https://documentation.spryker.com/docs/gift-cards) Abstract Configuration information on your Spryker Demo Shop. A **Gift Card Product** is a regular product in the shop which represents a Gift Card that Customer can buy. The **Gift Card Abstract Product** represents a type of Gift Cards with a code pattern (e.g. "XMAS-", “Happy-B”, etc.).
+This article contains content of the **gift_card_abstract_configuration.csv** file to configure [Gift Card](https://documentation.spryker.com/docs/gift-card) Abstract Configuration information on your Spryker Demo Shop. A **Gift Card Product** is a regular product in the shop which represents a Gift Card that Customer can buy. The **Gift Card Abstract Product** represents a type of Gift Cards with a code pattern (e.g. "XMAS-", “Happy-B”, etc.).
 
 ## Headers & Mandatory Fields 
 These are the header fields to be included in the .csv file:


### PR DESCRIPTION
broken link: https://documentation.spryker.com/docs/gift-cards
fixed link: https://documentation.spryker.com/docs/gift-card