### PR TITLE
Requiring minimum versions instead of exact

### DIFF
--- a/202009.0/28332910-9b1c-42ff-be83-422a8fca155a.md
+++ b/202009.0/28332910-9b1c-42ff-be83-422a8fca155a.md
@@ -9,8 +9,8 @@
 | **RabbitMQ**                                  | Version 3.6+                                                 |
 | **Jenkins (for cronjob management)**          | Version 1.6.x or 2.x          |
 | **Graphviz (for statemachine visualization)** | 2.x                                                          |
-|**Node.js**| Version 12.0.0 |
-|**NPM**| Version 6.9.0 |
+|**Node.js**| Version >= 12.0.0 |
+|**NPM**| Version >= 6.9.0 |
 |**Intranet**| Back Office application (Zed) must be secured in an Intranet (using VPN, Basic Auth, IP Allowlist, DMZ, etc.) |
 
 


### PR DESCRIPTION
Changed minimum versions for `node.js` and `npm` instead of exact version.