### PR TITLE
Update 174adeff-8507-4fb6-9d7c-df0299956f14.md

### DIFF
--- a/202108.0/174adeff-8507-4fb6-9d7c-df0299956f14.md
+++ b/202108.0/174adeff-8507-4fb6-9d7c-df0299956f14.md
@@ -229,7 +229,7 @@ We have done a complete revamp of the Spryker external libraries where we are de
 * Deprecated our PhantomJS dependencies for Chromedriver (Headless Chromium) with increase in speed and Codeception compatibility.
 * Updated Twig to v1.42 and v3^.
 * Updated Redis to v6.
-* Added PHP 8 compatibility, in Spryker as well as in Propel where we will be propping PHP 7.2 as deprecated.
+* Added PHP 8 compatibility, in Spryker as well as in Propel where we will be dropping PHP 7.2 as deprecated.
 
 #### Documentation
 


### PR DESCRIPTION
Changed possible typo "propping" to "dropping" as it seems to be more sensible that we _drop_ PHP 7.2 support in favor for PHP 8.0


