### PR TITLE
Fix Exchange description in "Set Up a Hello World Queue"

### DIFF
--- a/202001.0/d6331bbd-89a2-4e5c-9c24-4d0770d4d8ce.md
+++ b/202001.0/d6331bbd-89a2-4e5c-9c24-4d0770d4d8ce.md
@@ -105,7 +105,7 @@ class RabbitMqConfig extends SprykerRabbitMqConfig
 ?>
 ```
  
- @(Info)(Exchange)(Exchanges and why do I need them? The best practice for working with Rabbit MQ requires to not create queues directly in RabbitMQ but to use a gateway which binds to the queues. Gateways in RabbitMQ are called Exchanges.)
+ @(Info)(Exchange)(Exchanges and why do I need them? In RabbitMQ messages are sent to Exchanges, which have different types of routing. Exchange route messages to appropriate queue or multiple queues (zero or more).)
  
  The following image shows how the RabbitMQ exchange and queue work together. 
 ![RabbitMQ exchange](https://spryker.s3.eu-central-1.amazonaws.com/docs/Tutorials/Introduction/Set+up+Hello+World+Queue/rabbitmq_exchange.png){height="" width=""}


### PR DESCRIPTION
AMQP exchanges have nothing to do with queues creation, because queue is created and is available globally for all exchanges. So previous sentence was rephrased to more appropriate.


