### PR TITLE
Update dc0c3c0d-c1af-4949-9645-762c67f03c8a.md

### DIFF
--- a/202108.0/dc0c3c0d-c1af-4949-9645-762c67f03c8a.md
+++ b/202108.0/dc0c3c0d-c1af-4949-9645-762c67f03c8a.md
@@ -50,7 +50,7 @@ $config[OmsConstants::ACTIVE_PROCESSES] = [
 ```
     
 5. Check the state machine graph while building it.
-    1. Go to the **Maintenance → OMS** page in the Backend Office, you will see your state machine **Demo01**.
+    1. Go to the **Administration → OMS** page in the Backend Office, you will see your state machine **Demo01**.
     2. Click on it and you will see the graph that represents your XML file. 
 @(Info)()(Whenever you change the skeleton in the XML file, refresh the page so see the new changes.)
     


### PR DESCRIPTION
Fixes wrong OMS location in Zed nav tree


